### PR TITLE
Switch voice to ElevenLabs

### DIFF
--- a/app/api/twilio/voice/connect/operator/route.ts
+++ b/app/api/twilio/voice/connect/operator/route.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server';
 import twilio from 'twilio';
+import { getElevenLabsAudioUrl } from '@/lib/elevenlabs';
 
 export async function POST() {
   try {
@@ -109,10 +109,8 @@ export async function POST() {
 
     // エラー時のTwiMLを生成
     const errorTwiml = new twilio.twiml.VoiceResponse();
-    errorTwiml.say({
-      voice: 'Polly.Mizuki-Neural',
-      language: 'ja-JP'
-    }, '申し訳ありません。接続に問題が発生しました。');
+    const errorAudioUrl = await getElevenLabsAudioUrl('申し訳ありません。接続に問題が発生しました。');
+    errorTwiml.play(errorAudioUrl);
 
     return new Response(errorTwiml.toString(), {
       headers: {

--- a/app/api/twilio/voice/operator/route.ts
+++ b/app/api/twilio/voice/operator/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import twilio from "twilio";
+import { getElevenLabsAudioUrl } from "@/lib/elevenlabs";
 
 const VoiceResponse = twilio.twiml.VoiceResponse;
 
@@ -20,11 +21,11 @@ export async function POST(request: Request) {
 
   const response = new VoiceResponse();
   
-  // オペレーターへの接続メッセージ
-  response.say(
-    { voice: "Polly.Mizuki-Neural", language: "ja-JP" },
+  // オペレーターへの接続メッセージ（ElevenLabs 音声）
+  const connectAudioUrl = await getElevenLabsAudioUrl(
     "担当者にお繋ぎいたします。少々お待ちください。"
   );
+  response.play(connectAudioUrl);
 
   // オペレーターとの通話を開始
   response.dial({

--- a/app/api/twilio/voice/response/route.ts
+++ b/app/api/twilio/voice/response/route.ts
@@ -1,89 +1,15 @@
 // app/api/twilio/voice/response/route.ts の例
 import { NextResponse } from "next/server"
 import twilio from "twilio"
+import { getElevenLabsAudioUrl } from "@/lib/elevenlabs"
 
 const VoiceResponse = twilio.twiml.VoiceResponse
 
-// 会話履歴を保存するためのメモリ内ストレージ（本番環境では永続化ストレージを使用すべき）
-const conversationHistoryStore = new Map<string, string[]>();
-
-// ChatGPTのAPIを呼び出す関数
-async function getChatGPTResponse(userInput: string, callSid: string, step: string) {
-  try {
-    // 会話履歴を取得または初期化
-    const conversationHistory = conversationHistoryStore.get(callSid) || [];
-    
-    // ユーザー入力を履歴に追加
-    conversationHistory.push(`ユーザー: ${userInput}`);
-    
-    // ステップに応じたシステムプロンプトを設定
-    let systemPrompt = "あなたは合同会社AIコールの営業担当です。AI関連のサービスを販売する電話営業をしています。顧客側の担当者につなげることが目的です。";
-    
-    switch(step) {
-      case "1":
-        systemPrompt += "初めての会話です。相手の反応を踏まえて、担当者につなぐよう促してください。担当者がいない場合は、いつなら都合が良いか聞いてください。";
-        break;
-      case "2":
-        systemPrompt += "2回目の会話です。製品概要を簡潔に伝え、担当者に詳しい説明をしたいことを伝えてください。";
-        break;
-      case "3":
-        systemPrompt += "最後の会話です。担当者につなぐ前に、なぜこのサービスがお客様の会社に有益かを簡潔に伝え、担当者に取り次ぐことを明確に伝えてください。";
-        break;
-    }
-    
-    // ステップ3では、担当者に繋ぐ意図を明確にする
-    if (step === "3") {
-      systemPrompt += "必ず「それでは、弊社の担当者におつなぎしますので、少々お待ちください。」という文で終わらせてください。";
-    }
-
-    const response = await fetch("https://api.openai.com/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${process.env.OPENAI_API_KEY}`,
-      },
-      body: JSON.stringify({
-        model: "gpt-3.5-turbo",
-        messages: [
-          {
-            role: "system",
-            content: systemPrompt
-          },
-          ...conversationHistory.map(msg => ({
-            role: msg.startsWith("ユーザー: ") ? "user" : "assistant",
-            content: msg.replace(/^(ユーザー: |アシスタント: )/, "")
-          })),
-        ],
-        max_tokens: 150,
-        temperature: 0.7,
-      }),
-    })
-
-    if (!response.ok) {
-      throw new Error(`ChatGPT API error: ${response.statusText}`)
-    }
-
-    const data = await response.json()
-    const aiResponse = data.choices[0].message.content;
-    
-    // AIの応答を履歴に追加
-    conversationHistory.push(`アシスタント: ${aiResponse}`);
-    
-    // 更新された履歴を保存
-    conversationHistoryStore.set(callSid, conversationHistory);
-    
-    return aiResponse;
-  } catch (error) {
-    console.error("ChatGPT API error:", error)
-    return "申し訳ありません。エラーが発生しました。少々お待ちください。"
-  }
+async function addSpeech(res: twilio.twiml.VoiceResponse, text: string) {
+  const url = await getElevenLabsAudioUrl(text)
+  res.play(url)
 }
 
-// 次のステップを計算する関数
-function getNextStep(currentStep: string): string {
-  const step = parseInt(currentStep);
-  return (step < 3) ? (step + 1).toString() : "operator";
-}
 
 export async function POST(request: Request) {
   try {
@@ -104,15 +30,13 @@ export async function POST(request: Request) {
 
     const speechResult = formData.get("SpeechResult")
     const confidence = formData.get("Confidence")
-    const callSid = formData.get("CallSid")?.toString() || "unknown-call"
-    const timestamp = new Date().toISOString()
 
     // 音声認識の信頼度チェック
     const confidenceValue = parseFloat(confidence?.toString() || "0")
     if (confidenceValue < 0.5) {
       console.log("音声認識の信頼度が低いため、再試行します")
       const response = new VoiceResponse()
-      response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "申し訳ありません。もう一度お願いできますでしょうか？")
+      await addSpeech(response, "申し訳ありません。もう一度お願いできますでしょうか？")
       response.gather({
         input: ["speech"],
         language: "ja-JP",
@@ -135,8 +59,8 @@ export async function POST(request: Request) {
     // ステートごとの応答ロジック
     switch (state) {
       case "initial":
-        response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "すみません、実は本日、");
-        response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "初めてお電話をさせていただきました！");
+        await addSpeech(response, "すみません、実は本日、");
+        await addSpeech(response, "初めてお電話をさせていただきました！");
         response.gather({
           input: ["speech"],
           language: "ja-JP",
@@ -148,9 +72,9 @@ export async function POST(request: Request) {
         });
         break;
       case "first_response":
-        response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "弊社は生成ＡＩを使った新規顧客獲得テレアポのサービスを提供している会社でございまして、");
-        response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "是非、御社の営業の方にご案内できればと思いお電話をさせていただきました！");
-        response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "本日、営業の担当者さまはいらっしゃいますでしょうか？");
+        await addSpeech(response, "弊社は生成ＡＩを使った新規顧客獲得テレアポのサービスを提供している会社でございまして、");
+        await addSpeech(response, "是非、御社の営業の方にご案内できればと思いお電話をさせていただきました！");
+        await addSpeech(response, "本日、営業の担当者さまはいらっしゃいますでしょうか？");
         response.gather({
           input: ["speech"],
           language: "ja-JP",
@@ -162,9 +86,9 @@ export async function POST(request: Request) {
         });
         break;
       case "second_response":
-        response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "弊社は生成ＡＩを使った新規顧客獲得テレアポのサービスを提供している会社でございまして、");
-        response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "是非、御社の営業の方にご案内できればと思いお電話をさせていただきました！");
-        response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "本日、営業の担当者さまはいらっしゃいますでしょうか？");
+        await addSpeech(response, "弊社は生成ＡＩを使った新規顧客獲得テレアポのサービスを提供している会社でございまして、");
+        await addSpeech(response, "是非、御社の営業の方にご案内できればと思いお電話をさせていただきました！");
+        await addSpeech(response, "本日、営業の担当者さまはいらっしゃいますでしょうか？");
         response.gather({
           input: ["speech"],
           language: "ja-JP",
@@ -179,8 +103,8 @@ export async function POST(request: Request) {
         const userResponse = speechResult?.toString().toLowerCase() || "";
         
         if (userResponse.includes("社名") || userResponse.includes("会社名") || userResponse.includes("どちら様")) {
-          response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "ＡＩコールシステムの安達と申します。");
-          response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "本日、営業の担当者さまはいらっしゃいますでしょうか？");
+          await addSpeech(response, "ＡＩコールシステムの安達と申します。");
+          await addSpeech(response, "本日、営業の担当者さまはいらっしゃいますでしょうか？");
           response.gather({
             input: ["speech"],
             language: "ja-JP",
@@ -190,25 +114,25 @@ export async function POST(request: Request) {
             method: "POST",
             hints: "はい,いいえ,担当者,営業,お断り,ホームページ,また電話,失礼,結構,外出,会議,打ち合わせ,電話中"
           });
-        } else if (userResponse.includes("外出") || userResponse.includes("会議") || 
-                  userResponse.includes("打ち合わせ") || userResponse.includes("電話中") || 
+        } else if (userResponse.includes("外出") || userResponse.includes("会議") ||
+                  userResponse.includes("打ち合わせ") || userResponse.includes("電話中") ||
                   userResponse.includes("席を外") || userResponse.includes("不在")) {
-          response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "そうですか！");
-          response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "ではまたタイミングをみてお電話させていただきます。");
-          response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "ありがとうございました。");
+          await addSpeech(response, "そうですか！");
+          await addSpeech(response, "ではまたタイミングをみてお電話させていただきます。");
+          await addSpeech(response, "ありがとうございました。");
           response.pause({ length: 5 });
           response.hangup();
-        } else if (userResponse.includes("お断り") || userResponse.includes("結構") || 
+        } else if (userResponse.includes("お断り") || userResponse.includes("結構") ||
                   userResponse.includes("失礼") || userResponse.includes("要らない")) {
-          response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "そうですか！");
-          response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "大変失礼を致しました。");
-          response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "また何かございましたら、よろしくお願い致します。");
+          await addSpeech(response, "そうですか！");
+          await addSpeech(response, "大変失礼を致しました。");
+          await addSpeech(response, "また何かございましたら、よろしくお願い致します。");
           response.pause({ length: 5 });
           response.hangup();
-        } else if (userResponse.includes("ホームページ") || userResponse.includes("メール") || 
+        } else if (userResponse.includes("ホームページ") || userResponse.includes("メール") ||
                   userResponse.includes("問い合わせ") || userResponse.includes("書き込み")) {
-          response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "ではホームページから書き込みをさせていただきます。");
-          response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "ありがとうございました。");
+          await addSpeech(response, "ではホームページから書き込みをさせていただきます。");
+          await addSpeech(response, "ありがとうございました。");
           response.pause({ length: 5 });
           response.hangup();
         } else if (userResponse.includes("はい") || userResponse.includes("担当者")) {
@@ -216,7 +140,7 @@ export async function POST(request: Request) {
             method: "POST"
           }, `${process.env.NGROK_URL}/api/twilio/voice/connect/operator`);
         } else {
-          response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "申し訳ありません。もう一度お願いできますでしょうか？");
+          await addSpeech(response, "申し訳ありません。もう一度お願いできますでしょうか？");
           response.gather({
             input: ["speech"],
             language: "ja-JP",
@@ -229,9 +153,9 @@ export async function POST(request: Request) {
         }
         break;
       case "introduction":
-        response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "弊社は生成ＡＩを使った新規顧客獲得テレアポのサービスでございまして、");
-        response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "是非、御社の営業の方にご案内できればと思いお電話をさせていただきました！");
-        response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "本日、営業の担当者さまはいらっしゃいますでしょうか？");
+        await addSpeech(response, "弊社は生成ＡＩを使った新規顧客獲得テレアポのサービスでございまして、");
+        await addSpeech(response, "是非、御社の営業の方にご案内できればと思いお電話をさせていただきました！");
+        await addSpeech(response, "本日、営業の担当者さまはいらっしゃいますでしょうか？");
         response.gather({
           input: ["speech"],
           language: "ja-JP",
@@ -243,14 +167,13 @@ export async function POST(request: Request) {
         });
         break;
       case "schedule_callback":
-        const callbackTime = speechResult?.toString() || "";
-        response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "ご指定いただいた時間に、改めてお電話させていただきます。");
-        response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "ご対応いただき、ありがとうございました。");
+        await addSpeech(response, "ご指定いただいた時間に、改めてお電話させていただきます。");
+        await addSpeech(response, "ご対応いただき、ありがとうございました。");
         response.pause({ length: 2 });
         response.hangup();
         break;
       case "repeat_company":
-        response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "ＡＩコールシステムの安達と申します。");
+        await addSpeech(response, "ＡＩコールシステムの安達と申します。");
         response.gather({
           input: ["speech"],
           language: "ja-JP",
@@ -262,27 +185,27 @@ export async function POST(request: Request) {
         });
         break;
       case "unavailable":
-        response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "そうですか！");
-        response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "ではまたタイミングをみてお電話させていただきます。");
-        response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "ありがとうございました。");
+        await addSpeech(response, "そうですか！");
+        await addSpeech(response, "ではまたタイミングをみてお電話させていただきます。");
+        await addSpeech(response, "ありがとうございました。");
         response.pause({ length: 2 });
         response.hangup();
         break;
       case "rejection":
-        response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "そうですか！");
-        response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "大変失礼を致しました。");
-        response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "また何かございましたら、よろしくお願い致します。");
+        await addSpeech(response, "そうですか！");
+        await addSpeech(response, "大変失礼を致しました。");
+        await addSpeech(response, "また何かございましたら、よろしくお願い致します。");
         response.pause({ length: 2 });
         response.hangup();
         break;
       case "website":
-        response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "ではホームページから書き込みをさせていただきます。");
-        response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "ありがとうございました。");
+        await addSpeech(response, "ではホームページから書き込みをさせていただきます。");
+        await addSpeech(response, "ありがとうございました。");
         response.pause({ length: 2 });
         response.hangup();
         break;
       default:
-        response.say({ voice: "Polly.Mizuki", language: "ja-JP" }, "申し訳ありません。もう一度お願いできますでしょうか？");
+        await addSpeech(response, "申し訳ありません。もう一度お願いできますでしょうか？");
         response.gather({
           input: ["speech"],
           language: "ja-JP",
@@ -309,10 +232,7 @@ export async function POST(request: Request) {
     // エラー発生時は謝罪メッセージを返す
     try {
       const errorResponse = new VoiceResponse()
-      errorResponse.say({
-        voice: "Polly.Mizuki",
-        language: "ja-JP"
-      }, "申し訳ありません。システムエラーが発生しました。担当者におつなぎします。少々お待ちください。")
+      await addSpeech(errorResponse, "申し訳ありません。システムエラーが発生しました。担当者におつなぎします。少々お待ちください。")
       
       errorResponse.redirect({
         method: "POST"

--- a/app/api/twilio/voice/web-call/route.ts
+++ b/app/api/twilio/voice/web-call/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import twilio from "twilio";
+import { getElevenLabsAudioUrl } from "@/lib/elevenlabs";
 
 const VoiceResponse = twilio.twiml.VoiceResponse;
 
@@ -19,11 +20,11 @@ export async function POST(request: Request) {
 
   const response = new VoiceResponse();
   
-  // ウェブコールへの切り替えメッセージ
-  response.say(
-    { voice: "Polly.Mizuki-Neural", language: "ja-JP" },
+  // ウェブコールへの切り替えメッセージ（ElevenLabs 音声）
+  const webCallAudioUrl = await getElevenLabsAudioUrl(
     "ウェブコールに切り替えます。少々お待ちください。"
   );
+  response.play(webCallAudioUrl);
 
   // ウェブコールの設定
   const dial = response.dial({

--- a/lib/elevenlabs.ts
+++ b/lib/elevenlabs.ts
@@ -1,0 +1,41 @@
+import axios from "axios";
+import fs from "fs";
+import path from "path";
+import crypto from "crypto";
+
+const VOICE_ID = "Mv8AjrYZCBkdsmDHNwcB"; // Ishibashi の voice_id
+const MODEL_ID = "eleven_multilingual_v2";
+const ELEVENLABS_API_KEY = "sk_86037808263f9ab28e74649c4cc2694b256d3efc8f8e7558";
+const AUDIO_DIR = path.resolve("./public/audio");
+
+export async function getElevenLabsAudioUrl(text: string, fileName?: string): Promise<string> {
+  const name = fileName ?? `${crypto.createHash("md5").update(text).digest("hex")}.mp3`;
+  const filePath = path.join(AUDIO_DIR, name);
+  if (!fs.existsSync(AUDIO_DIR)) {
+    fs.mkdirSync(AUDIO_DIR, { recursive: true });
+  }
+  if (!fs.existsSync(filePath)) {
+    const audioBuffer = await generateSpeechFromElevenLabs(text);
+    fs.writeFileSync(filePath, audioBuffer);
+  }
+  return `${process.env.NGROK_URL}/audio/${name}`;
+}
+
+async function generateSpeechFromElevenLabs(text: string): Promise<Buffer> {
+  const url = `https://api.elevenlabs.io/v1/text-to-speech/${VOICE_ID}`;
+  const headers = {
+    "xi-api-key": ELEVENLABS_API_KEY,
+    "Content-Type": "application/json",
+    Accept: "audio/mpeg",
+  };
+  const body = {
+    text,
+    model_id: MODEL_ID,
+    voice_settings: {
+      stability: 0.5,
+      similarity_boost: 0.5,
+    },
+  };
+  const response = await axios.post(url, body, { headers, responseType: "arraybuffer" });
+  return Buffer.from(response.data);
+}


### PR DESCRIPTION
## Summary
- add an ElevenLabs helper to create and reuse speech audio
- generate operator connection and web-call prompts with ElevenLabs
- replace all Polly voice prompts with ElevenLabs audio

## Testing
- `npm run lint` *(fails: Unexpected any and unused variables in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_683fe3fb3f008321a07f51f9b26cb57d